### PR TITLE
Build bands with fixed sequence and front zone stacking

### DIFF
--- a/engine/src/bands.ts
+++ b/engine/src/bands.ts
@@ -1,0 +1,49 @@
+import { Item, FamilyBandConfig } from './types';
+
+export type Bands = {
+  EUP_stacked: Item[];
+  EUP_unstacked: Item[];
+  DIN_stacked: Item[];
+  DIN_unstacked: Item[];
+};
+
+export function expandUnits(items: Item[]): Item[] {
+  const expandedUnits: Item[] = [];
+
+  for (const originalItem of items) {
+    const quantity: number = typeof originalItem.qty === 'number' && originalItem.qty > 0 ? originalItem.qty : 1;
+
+    for (let unitIndex = 0; unitIndex < quantity; unitIndex += 1) {
+      const unit: Item = { ...originalItem, qty: 1 };
+      expandedUnits.push(unit);
+    }
+  }
+
+  return expandedUnits;
+}
+
+export function splitIntoBands(allItems: Item[], famCfgs: FamilyBandConfig[]): Bands {
+  const units: Item[] = expandUnits(allItems);
+
+  const familyToStackableCount: Record<'EUP' | 'DIN', number> = {
+    EUP: 0,
+    DIN: 0,
+  };
+
+  for (const cfg of famCfgs) {
+    familyToStackableCount[cfg.family] = Math.max(0, cfg.stackableCount);
+  }
+
+  const eupUnits: Item[] = units.filter((unit) => unit.family === 'EUP');
+  const dinUnits: Item[] = units.filter((unit) => unit.family === 'DIN');
+
+  const eupStackCount: number = Math.min(familyToStackableCount.EUP, eupUnits.length);
+  const dinStackCount: number = Math.min(familyToStackableCount.DIN, dinUnits.length);
+
+  return {
+    EUP_stacked: eupUnits.slice(0, eupStackCount),
+    EUP_unstacked: eupUnits.slice(eupStackCount),
+    DIN_stacked: dinUnits.slice(0, dinStackCount),
+    DIN_unstacked: dinUnits.slice(dinStackCount),
+  };
+}

--- a/engine/src/sequence.ts
+++ b/engine/src/sequence.ts
@@ -1,0 +1,40 @@
+import { Bands, splitIntoBands } from './bands';
+import { PackOptions, PlanResult, FamilyBandConfig, TruckPreset, Item } from './types';
+import { formColumns, applyFrontZoneDowngrade } from './stacking';
+import { packBandSequence } from './packer';
+
+export function planWithFixedSequence(
+  items: Item[],
+  famCfgs: FamilyBandConfig[],
+  preset: TruckPreset,
+  opts: PackOptions
+): PlanResult {
+  // a) build bands (units)
+  const initialBands: Bands = splitIntoBands(items, famCfgs);
+
+  // b) transform stacked units → columns
+  //    Note: column formation details are delegated; here we only convert the stacked-unit lists.
+  const stackedAsColumns: Bands = {
+    ...initialBands,
+    EUP_stacked: formColumns(initialBands.EUP_stacked, famCfgs),
+    DIN_stacked: formColumns(initialBands.DIN_stacked, famCfgs),
+  } as unknown as Bands;
+
+  // c) enforce stacked-only front zone via downgrade
+  const zoneCompliantBands: Bands = applyFrontZoneDowngrade(stackedAsColumns, preset, opts);
+
+  // d) pack in fixed sequence (skip empty bands)
+  const sequenceOrder = opts.fixedSequence;
+  const orderedNonEmptyBands: Array<{ key: keyof Bands; items: Item[] }> = [];
+
+  for (const key of sequenceOrder) {
+    const bandKey = key as keyof Bands;
+    const bandItems = zoneCompliantBands[bandKey] as unknown as Item[];
+    if (Array.isArray(bandItems) && bandItems.length > 0) {
+      orderedNonEmptyBands.push({ key: bandKey, items: bandItems });
+    }
+  }
+
+  const result: PlanResult = packBandSequence(orderedNonEmptyBands, preset, opts);
+  return result;
+}

--- a/engine/src/types.ts
+++ b/engine/src/types.ts
@@ -1,0 +1,36 @@
+export interface Item {
+  id?: string;
+  family: 'EUP' | 'DIN';
+  qty?: number; // defaults to 1 when omitted
+  // Allow additional properties without strict typing, carried through splitting
+  [key: string]: any;
+}
+
+export interface FamilyBandConfig {
+  family: 'EUP' | 'DIN';
+  stackableCount: number;   // units allowed to be stacked for this job
+  maxStackHeight: number;   // default 2
+}
+
+export interface PackOptions {
+  enforceRowPairConsistency: boolean;
+  aisleReserve?: number;         // mm at doors
+  frontStagingDepth: number;     // mm, stacked allowed only in [0..frontStagingDepth]
+  blockStrategy: 'fixed';        // fixed policy
+  fixedSequence: Array<'DIN_stacked' | 'EUP_stacked' | 'DIN_unstacked' | 'EUP_unstacked'>;
+}
+
+export interface TruckPreset {
+  id: string;
+  lengthMm: number;
+  widthMm: number;
+  heightMm: number;
+  [key: string]: any;
+}
+
+export interface PlanResult {
+  // Minimal shape; actual fields provided by the packing implementation
+  steps?: any[];
+  meta?: any;
+  [key: string]: any;
+}


### PR DESCRIPTION
Adds core logic for band building, partial stacking, and fixed-sequence packing with front zone enforcement.

---
<a href="https://cursor.com/background-agent?bcId=bc-6dd7a0dd-99e5-44b0-8802-5257526e5303">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-6dd7a0dd-99e5-44b0-8802-5257526e5303">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

